### PR TITLE
fix: provide the prefix str for consumption

### DIFF
--- a/client/services/ipam/models.go
+++ b/client/services/ipam/models.go
@@ -110,7 +110,7 @@ type Network struct {
 	SupernetId  string `json:"parent"`
 	Description string `json:"description"`
 	NameTag     string `json:"nameTag"`
-	PrefixStr   string `json:"prefix_str"`
+	PrefixStr   string `json:"prefixStr"`
 	HostAssign  bool   `json:"hostAssign"`
 	CreatedAt   string `json:"createdAt"`
 	UpdatedAt   string `json:"updatedAt"`


### PR DESCRIPTION
Previousy, prefix str was not correctly passed to the terraform resource definition. For this reason, it couldn't be used in other resources.