### PR TITLE
fix: adds proper replacement rules for ipam resources

### DIFF
--- a/cancom/services/ipam/resource_host.go
+++ b/cancom/services/ipam/resource_host.go
@@ -24,11 +24,13 @@ func resourceHost() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: false,
 				Required: true,
+				ForceNew: true,
 			},
 			"qualifier": {
 				Type:     schema.TypeString,
 				Computed: false,
 				Optional: true,
+				ForceNew: true,
 			},
 			"name_tag": {
 				Type:     schema.TypeString,

--- a/cancom/services/ipam/resource_network.go
+++ b/cancom/services/ipam/resource_network.go
@@ -24,6 +24,7 @@ func resourceNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: false,
 				Required: true,
+				ForceNew: true,
 			},
 			"name_tag": {
 				Type:     schema.TypeString,
@@ -39,6 +40,7 @@ func resourceNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: false,
 				Required: true,
+				ForceNew: true,
 			},
 			"host_assign": {
 				Type:     schema.TypeBool,

--- a/cancom/services/ipam/resource_supernet.go
+++ b/cancom/services/ipam/resource_supernet.go
@@ -39,6 +39,7 @@ func resourceSupernet() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: false,
 				Required: true,
+				ForceNew: true,
 			},
 			"created_at": {
 				Type:     schema.TypeString,

--- a/client/services/ipam/ipam.go
+++ b/client/services/ipam/ipam.go
@@ -54,7 +54,7 @@ func (c *Client) CreateNetwork(network *NetworkCreateRequest) (*Network, error) 
 		return nil, err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (c *Client) DeleteNetwork(networkId string) error {
 		return err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return err
 	}
@@ -161,7 +161,7 @@ func (c *Client) CreateSupernet(supernet *SupernetCreateRequest) (*Supernet, err
 		return nil, err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *Client) UpdateSupernet(supernetId string, supernet *SupernetUpdateReque
 		return nil, err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (c *Client) DeleteSupernet(supernetId string) error {
 		return err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return err
 	}
@@ -373,7 +373,7 @@ func (c *Client) CreateHost(host *HostCreateRequest) (*Host, error) {
 		return nil, err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -399,7 +399,7 @@ func (c *Client) UpdateHost(hostId string, host *HostUpdateRequest) (*Host, erro
 		return nil, err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (c *Client) DeleteHost(hostId string) error {
 		return err
 	}
 
-	body, err := (*client.Client)(c).DoRequest(req)
+	body, err := (*client.Client)(c).DoRequestWithRetry(req, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Supernets, Networks and Hosts are now replaced when certain properties changed (for example cidr, host ip, ...). These are values that cannot safely be updated, hence replacement rules were added.

Since these changes can result in lots of replacement requests, we also retry requests now.