### PR TITLE
fix: increase default http client timeout

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ type Client struct {
 
 func NewClient(host, token *string) (*Client, error) {
 	c := Client{
-		HTTPClient:  &http.Client{Timeout: 10 * time.Second},
+		HTTPClient:  &http.Client{Timeout: 2 * time.Minute},
 		ServiceURLs: map[string]string{},
 		HostURL:     HostURL,
 	}


### PR DESCRIPTION
This prevents the dns service for larger zones to properly wait for the answer of the server. Instead of overwriting this for the service, we increase the limit globally, since 10 seconds is not a reasonable value in the first place.