### PR TITLE
feat: detect expired tokens and renew automatically

### DIFF
--- a/client/service_registry.go
+++ b/client/service_registry.go
@@ -30,3 +30,28 @@ func (c *CcpClient) getAllServices() ([]Service, error) {
 
 	return services, nil
 }
+
+func (c *CcpClient) getSingleService(name string) (*Service, error) {
+	serviceRegistry, ok := c.services["service-registry"]
+	if !ok {
+		return nil, fmt.Errorf("service-registry not initialized")
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/v1/Services/%s", serviceRegistry.HostURL, name), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := serviceRegistry.DoRequest(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var service *Service
+	err = json.Unmarshal(body, &service)
+	if err != nil {
+		return nil, err
+	}
+
+	return service, nil
+}

--- a/client/token.go
+++ b/client/token.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+type tokenProvider struct {
+	mu           *sync.Mutex
+	token        string
+	currentToken string
+	expireTime   int64
+	role         string
+
+	iamClient *Client
+}
+
+func (t *tokenProvider) setToken(token string) error {
+
+	// Parse the JWT token to check expiration
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid token format: expected 3 parts but got %d", len(parts))
+	}
+
+	// Decode the payload (second part)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return err
+	}
+
+	// Parse the JSON payload
+	var claims struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return err
+	}
+
+	t.currentToken = token
+	t.expireTime = claims.Exp - int64((5 * time.Minute).Seconds())
+
+	return nil
+}
+
+func (t *tokenProvider) GetToken() (string, error) {
+	// base case - no role never needs to check expired tokens
+	if t.role == "" {
+		return t.token, nil
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if time.Now().Unix() > t.expireTime {
+		// need to refresh token
+		req, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/AssumeRole", t.iamClient.HostURL), strings.NewReader(fmt.Sprintf(`{"role": "%s"}`, t.role)))
+		if err != nil {
+			return "", err
+		}
+
+		resp, err := t.iamClient.DoRequest(req)
+		if err != nil {
+			return "", err
+		}
+
+		var token struct {
+			Token string `json:"jwt"`
+		}
+
+		err = json.Unmarshal(resp, &token)
+		if err != nil {
+			return "", err
+		}
+
+		if err := t.setToken(token.Token); err != nil {
+			return "", err
+		}
+	}
+
+	return t.currentToken, nil
+}


### PR DESCRIPTION
The assume role functionality has moved from terraform into the client. The client now monitors the session and, if necessary, refreshes the token if it is expired due to assume role being used.