### PR TITLE
fix: Windows OS Errorhandling

### DIFF
--- a/cancom/services/windows-os/data_deployment_progess.go
+++ b/cancom/services/windows-os/data_deployment_progess.go
@@ -1,8 +1,12 @@
 package windowsos
 
 import (
+	"context"
+
 	"github.com/cancom/terraform-provider-cancom/client"
 	client_windowsos "github.com/cancom/terraform-provider-cancom/client/services/windows-os"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -12,7 +16,7 @@ func dataWindowsOSDeploymentProgress() *schema.Resource {
 		
 This can be used for dependency tracking purposes and returns in case of failure errors.  
 The required` + " `deployment_id` " + `represents the id of` + " `cancom_windows_os_deployment` " + `resource.`,
-		Read: WindowsOSDeploymentProgressRead,
+		ReadContext: WindowsOSDeploymentProgressRead,
 		Schema: map[string]*schema.Schema{
 			"deployment_id": {
 				Type:        schema.TypeString,
@@ -28,11 +32,12 @@ The required` + " `deployment_id` " + `represents the id of` + " `cancom_windows
 	}
 }
 
-func WindowsOSDeploymentProgressRead(d *schema.ResourceData, meta interface{}) error {
+func WindowsOSDeploymentProgressRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	c, err := meta.(*client.CcpClient).GetService("managed-windows")
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
+	tflog.Debug(ctx, "Started Windows Deployment Progress")
 
 	// if a status is already set, we can avoid calling the endpoint again.
 	if d.Get("state").(string) == "Finished" {
@@ -42,18 +47,18 @@ func WindowsOSDeploymentProgressRead(d *schema.ResourceData, meta interface{}) e
 	} else if d.Get("state").(string) == "Started" {
 		return nil
 	}
+	tflog.Debug(ctx, "Finished Pre-Check")
 
-	// set initial status
 	d.SetId(d.Get("deployment_id").(string))
 	d.Set("state", "Started")
 
+	tflog.Debug(ctx, "Updated State")
 	resp, err := (*client_windowsos.Client)(c).CreateWindowsDeploymentStatus(d.Get("deployment_id").(string))
 	if err != nil {
 		d.SetId(d.Get("deployment_id").(string))
 		d.Set("state", "Failed")
-		return err
+		return diag.FromErr(err)
 	}
-
 	d.SetId(resp.Id)
 	d.Set("state", "Finished")
 

--- a/cancom/services/windows-os/data_deployment_progess.go
+++ b/cancom/services/windows-os/data_deployment_progess.go
@@ -33,12 +33,19 @@ func WindowsOSDeploymentProgressRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+
 	// if a status is already set, we can avoid calling the endpoint again.
 	if d.Get("state").(string) == "Finished" {
 		return nil
 	} else if d.Get("state").(string) == "Failed" {
 		return nil
+	} else if d.Get("state").(string) == "Started" {
+		return nil
 	}
+
+	// set initial status
+	d.SetId(d.Get("deployment_id").(string))
+	d.Set("state", "Started")
 
 	resp, err := (*client_windowsos.Client)(c).CreateWindowsDeploymentStatus(d.Get("deployment_id").(string))
 	if err != nil {


### PR DESCRIPTION
This prevents errors if the backend failed and does not set the state of the dataobject properly.